### PR TITLE
ci: run action check integration test only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: Continuous Integration
 
 on:
   pull_request:
-  push:
     branches:
       - main
+    types:
+      - opened
+      - edited
+      - synchronize
 
 permissions:
   contents: read


### PR DESCRIPTION
Run action integration test only on pull requests and not on master since action should have an access to the pull request title